### PR TITLE
fixed calls to setupAtlas and asetup

### DIFF
--- a/pilot/control/payload.py
+++ b/pilot/control/payload.py
@@ -67,11 +67,11 @@ def _validate_payload(job):
 def setup_payload(job, out, err):
     log = logger.getChild(str(job['PandaID']))
 
-    jobDir = 'job-%s/' % job['PandaID']
-    dbDir = '/cvmfs/atlas.cern.ch/repo/sw/database/DBRelease/current/'
+    jobdir = 'job-%s/' % job['PandaID']
+    dbdir = '/cvmfs/atlas.cern.ch/repo/sw/database/DBRelease/current/'
 
     # create symbolic link for sqlite200 and geomDB in job dir
-    executable = ['ln', '-sf', dbDir + 'sqlite200', dbDir + 'geomDB', jobDir]
+    executable = ['ln', '-sf', dbdir + 'sqlite200', dbdir + 'geomDB', jobdir]
 
     log.debug('executable=%s' % executable)
 
@@ -87,15 +87,15 @@ def setup_payload(job, out, err):
 def run_payload(job, out, err):
     log = logger.getChild(str(job['PandaID']))
 
-    setupExecStr = 'source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh --quiet; '\
-                   'source $AtlasSetup/scripts/asetup.sh %s,here; ' % job['homepackage'].split('/')[1]
+    asetup = 'source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh --quiet; '\
+             'source $AtlasSetup/scripts/asetup.sh %s,here; ' % job['homepackage'].split('/')[1]
 
-    runExecStr = job['transformation'] + ' ' + job['jobPars']
+    cmd = job['transformation'] + ' ' + job['jobPars']
 
-    log.debug('executable=%s' % setupExecStr + runExecStr)
+    log.debug('executable=%s' % asetup + cmd)
 
     try:
-        proc = subprocess.Popen(setupExecStr + runExecStr,
+        proc = subprocess.Popen(asetup + cmd,
                                 bufsize=-1,
                                 stdout=out,
                                 stderr=err,
@@ -105,7 +105,7 @@ def run_payload(job, out, err):
         log.error('could not execute: %s' % str(e))
         return None
 
-    log.info('started -- pid=%s executable=%s' % (proc.pid, setupExecStr + runExecStr))
+    log.info('started -- pid=%s executable=%s' % (proc.pid, asetup + cmd))
 
     return proc
 

--- a/pilot/control/payload.py
+++ b/pilot/control/payload.py
@@ -7,12 +7,11 @@
 # Authors:
 # - Mario Lassnig, mario.lassnig@cern.ch, 2016-2017
 # - Daniel Drizhuk, d.drizhuk@gmail.com, 2017
+# - Tobias Wegner, tobias.wegner@cern.ch, 2017
 
 import Queue
-import commands
 import json
 import os
-import shlex
 import subprocess
 import threading
 import time
@@ -68,23 +67,18 @@ def _validate_payload(job):
 def setup_payload(job, out, err):
     log = logger.getChild(str(job['PandaID']))
 
-    executable = 'cd job-%s; '\
-                 'ln -sf /cvmfs/atlas.cern.ch/repo/sw/database/DBRelease/current/sqlite200 sqlite200; '\
-                 'ln -sf /cvmfs/atlas.cern.ch/repo/sw/database/DBRelease/current/geomDB geomDB; '\
-                 'source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh --quiet; '\
-                 'source $AtlasSetup/scripts/asetup.sh %s,here; cd ..' % (job['PandaID'],
-                                                                          job['homepackage'].split('/')[1])
+    jobDir = 'job-%s/' % job['PandaID']
+    dbDir = '/cvmfs/atlas.cern.ch/repo/sw/database/DBRelease/current/'
+
+    # create symbolic link for sqlite200 and geomDB in job dir
+    executable = ['ln', '-sf', dbDir + 'sqlite200', dbDir + 'geomDB', jobDir]
 
     log.debug('executable=%s' % executable)
 
     try:
-        s, o = commands.getstatusoutput(executable)
+        subprocess.check_call(executable)
     except Exception as e:
-        log.error('could not setup environment: %s' % e)
-        return False
-
-    if s != 0:
-        log.error('could not setup environment: %s' % o)
+        log.error('could not create symbolic links to database files: %s' % e)
         return False
 
     return True
@@ -93,20 +87,25 @@ def setup_payload(job, out, err):
 def run_payload(job, out, err):
     log = logger.getChild(str(job['PandaID']))
 
-    executable = ['/usr/bin/env', job['transformation']] + shlex.split(job['jobPars'])
-    log.debug('executable=%s' % executable)
+    setupExecStr = 'source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh --quiet; '\
+                   'source $AtlasSetup/scripts/asetup.sh %s,here; ' % job['homepackage'].split('/')[1]
+
+    runExecStr = job['transformation'] + ' ' + job['jobPars']
+
+    log.debug('executable=%s' % setupExecStr + runExecStr)
 
     try:
-        proc = subprocess.Popen(executable,
+        proc = subprocess.Popen(setupExecStr + runExecStr,
                                 bufsize=-1,
                                 stdout=out,
                                 stderr=err,
-                                cwd=job['working_dir'])
+                                cwd=job['working_dir'],
+                                shell=True)
     except Exception as e:
         log.error('could not execute: %s' % str(e))
         return None
 
-    log.info('started -- pid=%s executable=%s' % (proc.pid, executable))
+    log.info('started -- pid=%s executable=%s' % (proc.pid, setupExecStr + runExecStr))
 
     return proc
 


### PR DESCRIPTION
Because atlasLocalSetup and asetup got sourced in an extra process, the environment was already cleaned up when executing the actual payload. This patches sources the scripts from within the same process.