### PR TITLE
add exception structure

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -6,10 +6,28 @@
 #
 # Authors:
 # - Mario Lassnig, mario.lassnig@cern.ch, 2017
+# - Wen Guan, wen.guan@cern.ch, 2017
 
 import os
 
 from pilot.control import data
+
+
+class TransferRequest(object):
+    """
+    Transfer request to handle files stagein/stageout
+    """
+
+    _attrs = ['type']  # stagein, stageout, ...
+    _attrs += ['scope', 'name', 'guid', 'filesize', 'checksum']  # file info
+    _attrs += ['dataset', 'ddmendpoint', 'jobqueue']
+    _attrs += ['objectstoreId']  # special for ES
+    _attrs += ['allowRemoteInputs']  # control options
+    _attrs += ['status', 'destPfn']  # transfer result
+
+    def __init__(self, **kwargs):
+        for k in self._attrs:
+            setattr(self, k, kwargs.get(k, getattr(self, k, None)))
 
 
 class StageInClient(object):

--- a/pilot/exceptions/__init__.py
+++ b/pilot/exceptions/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+Exceptions
+"""

--- a/pilot/exceptions/exception.py
+++ b/pilot/exceptions/exception.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+Exceptions in pilot
+"""
+
+
+class PilotException(Exception):
+    """
+    The basic exception class.
+    The pilot error code can be defined here, where the pilot error code will
+    be propageted to job server.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(PilotException, self).__init__(args, kwargs)
+        self._errorCode = 0
+        self._message = "An unknown pilot exception occurred."
+        self.args = args
+        self.kwargs = kwargs
+        self._error_string = None
+
+    def __str__(self):
+        try:
+            self._error_string = self._message % self.kwargs
+        except Exception:
+            # at least get the core message out if something happened
+            self._error_string = self._message
+        if len(self.args) > 0:
+            # If there is a non-kwarg parameter, assume it's the error
+            # message or reason description and tack it on to the end
+            # of the exception message
+            # Convert all arguments into their string representations...
+            args = ["%s" % arg for arg in self.args if arg]
+            self._error_string = (self._error_string + "\nDetails: %s" % '\n'.join(args))
+        return self._error_string.strip()
+
+
+class NotImplemented(PilotException):
+    """
+    NotImplemented
+    """
+    def __init__(self, *args, **kwargs):
+        super(NotImplemented, self).__init__(args, kwargs)
+        self._message = "The class or function is not implemented."

--- a/pilot/gateway/__init__.py
+++ b/pilot/gateway/__init__.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+An interface package to talk with other system such
+as Panda, aCT, Harvester, Tracer
+"""

--- a/pilot/gateway/jobServer/__init__.py
+++ b/pilot/gateway/jobServer/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+An interface package to talk with job server such as panda, aCT, harvester
+"""

--- a/pilot/gateway/jobServer/aCTJobServer.py
+++ b/pilot/gateway/jobServer/aCTJobServer.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A default interface to talk to aCT server to get jobs, update status
+"""
+
+import traceback
+
+from pilot.exceptions import exception
+from pilot.gateway.jobServer.defaultJobServer import DefaultJobServer
+
+
+class ACTJobServer(DefaultJobServer):
+    def __init__(self):
+        pass
+
+    def get_jobs(self, data):
+        """
+        Get job from the job server.
+
+        param data: Dictionary for retrieving jobs
+        returns: List of jobs.
+        exception: Fail to get a job or jobs
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def update_job(self, data):
+        """
+        Update job to the job server.
+
+        param data: Dictionary for updating a job
+        exception: Fail to update a job
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def get_event_ranges(self, data):
+        """
+        Get event ranges from the job server.
+
+        param data: Dictionary for retrieving event ranges
+        returns: List of event ranges
+        exception: Fail to get event ranges
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def update_event_ranges(self, data):
+        """
+        Update event ranges to the job server.
+
+        param data: Dictionary for updating event ranges
+        exception: Fail to update event ranges
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/jobServer/defaultJobServer.py
+++ b/pilot/gateway/jobServer/defaultJobServer.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A default interface to talk to job server to get jobs, update status
+"""
+
+
+import traceback
+
+from pilot.exceptions import exception
+
+
+class DefaultJobServer(object):
+    def __init__(self):
+        pass
+
+    def get_jobs(self, data):
+        """
+        Get job from the job server.
+
+        param data: Dictionary for retrieving jobs
+        returns: List of jobs.
+        exception: Fail to get a job or jobs
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def update_job(self, data):
+        """
+        Update job to the job server.
+
+        param data: Dictionary for updating a job
+        exception: Fail to update a job
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def get_event_ranges(self, data):
+        """
+        Get event ranges from the job server.
+
+        param data: Dictionary for retrieving event ranges
+        returns: List of event ranges
+        exception: Fail to get event ranges
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def update_event_ranges(self, data):
+        """
+        Update event ranges to the job server.
+
+        param data: Dictionary for updating event ranges
+        exception: Fail to update event ranges
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/jobServer/harverterJobServer.py
+++ b/pilot/gateway/jobServer/harverterJobServer.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A default interface to talk to harvester to get jobs, update status
+"""
+
+
+import traceback
+
+from pilot.exceptions import exception
+from pilot.gateway.jobServer.defaultJobServer import DefaultJobServer
+
+
+class PandaJobServer(DefaultJobServer):
+    def __init__(self):
+        pass
+
+    def get_jobs(self, data):
+        """
+        Get job from the job server.
+
+        param data: Dictionary for retrieving jobs
+        returns: List of jobs.
+        exception: Fail to get a job or jobs
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def update_job(self, data):
+        """
+        Update job to the job server.
+
+        param data: Dictionary for updating a job
+        exception: Fail to update a job
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def get_event_ranges(self, data):
+        """
+        Get event ranges from the job server.
+
+        param data: Dictionary for retrieving event ranges
+        returns: List of event ranges
+        exception: Fail to get event ranges
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def update_event_ranges(self, data):
+        """
+        Update event ranges to the job server.
+
+        param data: Dictionary for updating event ranges
+        exception: Fail to update event ranges
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/jobServer/pandaJobServer.py
+++ b/pilot/gateway/jobServer/pandaJobServer.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A default interface to talk to panda server to get jobs, update status
+"""
+
+
+import traceback
+
+from pilot.exceptions import exception
+from pilot.gateway.jobServer.defaultJobServer import DefaultJobServer
+
+
+class PandaJobServer(DefaultJobServer):
+    def __init__(self):
+        pass
+
+    def get_jobs(self, data):
+        """
+        Get job from the job server.
+
+        param data: Dictionary for retrieving jobs
+        returns: List of jobs.
+        exception: Fail to get a job or jobs
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def update_job(self, data):
+        """
+        Update job to the job server.
+
+        param data: Dictionary for updating a job
+        exception: Fail to update a job
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def get_event_ranges(self, data):
+        """
+        Get event ranges from the job server.
+
+        param data: Dictionary for retrieving event ranges
+        returns: List of event ranges
+        exception: Fail to get event ranges
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())
+
+    def update_event_ranges(self, data):
+        """
+        Update event ranges to the job server.
+
+        param data: Dictionary for updating event ranges
+        exception: Fail to update event ranges
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/jobServerFactory.py
+++ b/pilot/gateway/jobServerFactory.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A factory to generate instance to talk with different job server,
+such as Panda, aCT, harverter
+"""
+
+import traceback
+
+from pilot.exceptions import exception
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class JobServerFactory(object):
+    def __init__(self):
+        pass
+
+    def create_job_server(self, options={'jobserver': 'pandaJobServer.PandaJobServer'}):
+        if 'jobserver' in options:
+            jobserver = options['jobserver']
+        jobserver = 'pilot.gateway.%s' % jobserver
+
+        logger.info("Importing job server %s" % jobserver)
+        try:
+            components = jobserver.split('.')
+            mod = __import__('.'.join(components[:-1]))
+            for comp in components[1:]:
+                mod = getattr(mod, comp)
+            server = mod(options)
+            return server
+        except Exception:
+            raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/siteInfo/__init__.py
+++ b/pilot/gateway/siteInfo/__init__.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+An interface package to get site info such as schedconf queue data,
+ddm config data
+"""

--- a/pilot/gateway/siteInfo/agisSiteInfo.py
+++ b/pilot/gateway/siteInfo/agisSiteInfo.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A default interface to send tracer info
+"""
+
+
+import traceback
+
+from pilot.exceptions import exception
+from pilot.gateway.siteInfo.defaultSiteInfo import DefaultSiteInfo
+
+
+class AGISSiteInfo(DefaultSiteInfo):
+    def __init__(self):
+        pass
+
+    def get_site_info(self, data):
+        """
+        Get site information.
+
+        param data: Dictionary for retrieving site info.
+        returns: Site Info object.
+        exception: Fail to get site info.
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/siteInfo/defaultSiteInfo.py
+++ b/pilot/gateway/siteInfo/defaultSiteInfo.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A default interface to send tracer info
+"""
+
+
+import traceback
+
+from pilot.exceptions import exception
+
+
+class DefaultSiteInfo(object):
+    def __init__(self):
+        pass
+
+    def get_site_info(self, data):
+        """
+        Get site information.
+
+        param data: Dictionary for retrieving site info.
+        returns: Site Info object.
+        exception: Fail to get site info.
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/siteInfoFactory.py
+++ b/pilot/gateway/siteInfoFactory.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A factory to generate instance to get site info.
+"""
+
+import traceback
+
+from pilot.exceptions import exception
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class SiteInfoFactory(object):
+    def __init__(self):
+        pass
+
+    def create_site_info(self, options={'siteinfo': 'agisSiteInfo.AGISSiteInfo'}):
+        if 'siteinfo' in options:
+            siteinfo = options['siteinfo']
+        siteinfo = 'pilot.gateway.siteinfo.%s' % siteinfo
+
+        logger.info("Importing siteinfo %s" % siteinfo)
+        try:
+            components = siteinfo.split('.')
+            mod = __import__('.'.join(components[:-1]))
+            for comp in components[1:]:
+                mod = getattr(mod, comp)
+            siteinfo = mod(options)
+            return siteinfo
+        except Exception:
+            raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/tracer/__init__.py
+++ b/pilot/gateway/tracer/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+An interface package to send tracer info out
+"""

--- a/pilot/gateway/tracer/defaultTracer.py
+++ b/pilot/gateway/tracer/defaultTracer.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A default interface to send tracer info
+"""
+
+
+import traceback
+
+from pilot.exceptions import exception
+
+
+class DefaultTracer(object):
+    def __init__(self):
+        pass
+
+    def send_trace(self, data):
+        """
+        send trace information.
+
+        param data: Dictionary for updating a job.
+        exception: Fail to send trace info.
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/tracer/rucioTracer.py
+++ b/pilot/gateway/tracer/rucioTracer.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A default interface to send tracer info
+"""
+
+
+import traceback
+
+from pilot.exceptions import exception
+from pilot.gateway.tracer.defaultTracer import DefaultTracer
+
+
+class RucioTracer(DefaultTracer):
+    def __init__(self):
+        pass
+
+    def send_trace(self, data):
+        """
+        send trace information.
+
+        param data: Dictionary for updating a job.
+        exception: Fail to send trace info.
+        """
+
+        raise exception.NotImplemented(traceback.format_exc())

--- a/pilot/gateway/tracerFactory.py
+++ b/pilot/gateway/tracerFactory.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+A factory to generate instance to talk with tracer server
+"""
+
+import traceback
+
+from pilot.exceptions import exception
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class TracerFactory(object):
+    def __init__(self):
+        pass
+
+    def create_tracer(self, options={'tracer': 'rucioTracer.RucioTracer'}):
+        if 'tracer' in options:
+            tracer = options['tracer']
+        tracer = 'pilot.gateway.%s' % tracer
+
+        logger.info("Importing tracer %s" % tracer)
+        try:
+            components = tracer.split('.')
+            mod = __import__('.'.join(components[:-1]))
+            for comp in components[1:]:
+                mod = getattr(mod, comp)
+            tracer = mod(options)
+            return tracer
+        except Exception:
+            raise exception.NotImplemented(traceback.format_exc())


### PR DESCRIPTION
It's good to have exception structure.
In the old pilot, it's painful to return a correct error code(The main function has many layer of calling stack. You need to handle the error code in every calling stack).

I found that in job.py, the panda server is hard coded there. But in fact, pilot can get jobs from panda(in most cases), from aCT(it's totally different with the case to get jobs from panda, it just reads a local file), from harvester(harvester messager, from local file). For the new case for boinc event service, there maybe will some other differences.

For agis and tracer, the case is the same. The site info has changed many times, from schedconf, to agis, to cvmfs. The tracer is using rucio http interface, maybe it will use messanger such as ActiveMQ in the future, so so.

For all these cases, we should have an interface to do it, instead of hardcoding them in the main pilot workflow.