### PR TITLE
add transfer request

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -6,10 +6,28 @@
 #
 # Authors:
 # - Mario Lassnig, mario.lassnig@cern.ch, 2017
+# - Wen Guan, wen.guan@cern.ch, 2017
 
 import os
 
 from pilot.control import data
+
+
+class TransferRequest(object):
+    """
+    Transfer request to handle files stagein/stageout
+    """
+
+    _attrs = ['type']  # stagein, stageout, ...
+    _attrs += ['scope', 'name', 'guid', 'filesize', 'checksum']  # file info
+    _attrs += ['dataset', 'ddmendpoint', 'jobqueue']
+    _attrs += ['objectstoreId']  # special for ES
+    _attrs += ['allowRemoteInputs']  # control options
+    _attrs += ['status', 'destPfn']  # transfer result
+
+    def __init__(self, **kwargs):
+        for k in self._attrs:
+            setattr(self, k, kwargs.get(k, getattr(self, k, None)))
 
 
 class StageInClient(object):


### PR DESCRIPTION
add a transfer request layer.

In pilot2, the site mover should based on rucio. But it's not good to hardcoded with rucio. I was thinking to add a gateway layer for all systems which pilot will connect. I did do it for site mover part. But it's good not to hardcoded rucio.

In pilot1, pilot depended on dq2 so heavily. When dq2 grew to rucio. It's painful in pilot. The code is not clean.

Another thing, how to handle direct_access and lsm?