### PR TITLE
add execeptions

### DIFF
--- a/pilot/exceptions/__init__.py
+++ b/pilot/exceptions/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+Exceptions
+"""

--- a/pilot/exceptions/exception.py
+++ b/pilot/exceptions/exception.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Wen Guan, wen.guan@cern.ch, 2017
+
+"""
+Exceptions in pilot
+"""
+
+
+class PilotException(Exception):
+    """
+    The basic exception class.
+    The pilot error code can be defined here, where the pilot error code will
+    be propageted to job server.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(PilotException, self).__init__(args, kwargs)
+        self._errorCode = 0
+        self._message = "An unknown pilot exception occurred."
+        self.args = args
+        self.kwargs = kwargs
+        self._error_string = None
+
+    def __str__(self):
+        try:
+            self._error_string = self._message % self.kwargs
+        except Exception:
+            # at least get the core message out if something happened
+            self._error_string = self._message
+        if len(self.args) > 0:
+            # If there is a non-kwarg parameter, assume it's the error
+            # message or reason description and tack it on to the end
+            # of the exception message
+            # Convert all arguments into their string representations...
+            args = ["%s" % arg for arg in self.args if arg]
+            self._error_string = (self._error_string + "\nDetails: %s" % '\n'.join(args))
+        return self._error_string.strip()
+
+
+class NotImplemented(PilotException):
+    """
+    NotImplemented
+    """
+    def __init__(self, *args, **kwargs):
+        super(NotImplemented, self).__init__(args, kwargs)
+        self._message = "The class or function is not implemented."


### PR DESCRIPTION
It's painful in pilot1 to handle return code.

When one error code is raised in a deep stack calling, many functions called this function have to handle this error code. So I would suggest to use exception framework with different exceptions for different error code.